### PR TITLE
Remove test prefix from source class candidate

### DIFF
--- a/src/main/kotlin/mappers/ClassMapper.kt
+++ b/src/main/kotlin/mappers/ClassMapper.kt
@@ -29,7 +29,7 @@ class ClassMapper(
     }
 
     private fun classNameTokenSubsetHeuristics(testClassMeta: ClassMeta): SourceClassInfo? {
-        val testClassNameWithoutTestSuffix = removeSingleTestSuffix(testClassMeta.name)
+        val testClassNameWithoutTestSuffix = removeSingleTestSuffixOrPrefix(testClassMeta.name)
         val sourceClassCandidates = mutableListOf<SourceClassInfo>()
         processClassNameCandidate(testClassNameWithoutTestSuffix, testClassMeta, sourceClassCandidates)
         if (sourceClassCandidates.size == 1) return sourceClassCandidates[0]
@@ -77,10 +77,24 @@ class ClassMapper(
 
     companion object {
         private val TEST_SUFFIXES = arrayOf("Test", "Tests", "TestCase", "IT", "ITCase")
+        private val TEST_PREFIXES = arrayOf("Test", "IT")
 
-        internal fun removeSingleTestSuffix(className: String): String {
+        internal fun removeSingleTestSuffixOrPrefix(className: String) = removeSingleTestSuffix(className).let {
+            if (it === className) removeSingleTestPrefix(it) else it
+        }
+
+        private fun removeSingleTestSuffix(className: String): String {
             TEST_SUFFIXES.forEach { suffix ->
                 className.removeSuffix(suffix).let {
+                    if (it !== className) return it
+                }
+            }
+            return className
+        }
+
+        private fun removeSingleTestPrefix(className: String): String {
+            TEST_PREFIXES.forEach { prefix ->
+                className.removePrefix(prefix).let {
                     if (it !== className) return it
                 }
             }

--- a/src/test/kotlin/mappers/ClassMapperImplTest.kt
+++ b/src/test/kotlin/mappers/ClassMapperImplTest.kt
@@ -14,9 +14,12 @@ class ClassMapperImplTest {
         "ImplIT,Impl",
         "ImplITCase,Impl",
         "ImplITTest,ImplIT",
+        "TestImpl,Impl",
+        "ITImpl,Impl",
+        "TestImplIT,TestImpl",
     )
-    fun removeSingleTestSuffix(input: String, expectedOutput: String) {
-        assertEquals(expectedOutput, ClassMapper.removeSingleTestSuffix(input))
+    fun removeSingleTestSuffixOrPrefix(input: String, expectedOutput: String) {
+        assertEquals(expectedOutput, ClassMapper.removeSingleTestSuffixOrPrefix(input))
     }
 
     @Test


### PR DESCRIPTION
The PR removes one of documented test class name prefixes. Before that, only suffixes were removed to predict source class.
See https://maven.apache.org/surefire/maven-surefire-plugin/examples/inclusion-exclusion.html
https://maven.apache.org/surefire/maven-failsafe-plugin/examples/inclusion-exclusion.html