### PR TITLE
Support vararg include declaration in settings.gradle

### DIFF
--- a/src/main/kotlin/BuildSystem.kt
+++ b/src/main/kotlin/BuildSystem.kt
@@ -15,7 +15,11 @@ enum class BuildSystem {
         override fun getProjectModules(projectPath: File): Map<String, File> =
             findConfigFile(projectPath, "settings")?.let { settings ->
                 extractModuleNames(projectPath, settings, moduleImportsRegex) { matchResult ->
-                    extractModuleNamesRegex.findAll(matchResult.groupValues[1]).map { it.value }
+                    extractModuleNamesRegex.findAll(matchResult.groupValues[1])
+                        // In Gradle, colon is used as path separator, so normalize project name to match FS path
+                        .map { it.value.removePrefix(":").replace(':', File.separatorChar)
+                            .let { projectName -> getProjectModules(File(projectPath, projectName)) }
+                        }.fold(LinkedHashMap()) { acc, map -> acc.apply { putAll(map) }}
                 }
             } ?: super.getProjectModules(projectPath)
 
@@ -27,9 +31,11 @@ enum class BuildSystem {
         private val moduleNameRegex = "(?<=<module>)[^<]*(?=</module>)".toRegex()
 
         override fun getProjectModules(projectPath: File): Map<String, File> {
-            val pomFile = File(projectPath, "pom.xml")
-            return extractModuleNames(projectPath, pomFile, moduleNameRegex) { sequenceOf(it.value) }
-                ?: super.getProjectModules(projectPath)
+            return File(projectPath, "pom.xml").takeIf { it.isFile }?.let { pomFile ->
+                extractModuleNames(projectPath, pomFile, moduleNameRegex) {
+                    getProjectModules(File(projectPath, it.value))
+                }
+            } ?: super.getProjectModules(projectPath)
         }
     },
     ANT, OTHER;
@@ -45,14 +51,13 @@ private fun extractModuleNames(
     projectPath: File,
     settingsFile: File,
     regex: Regex,
-    extractor: (MatchResult) -> Sequence<String>
+    extractor: (MatchResult) -> Map<String, File>
 ): Map<String, File>? =
     regex.findAll(settingsFile.readText())
-        .flatMap(extractor)
-        .map { it to File(projectPath, it.replace(':', '/')) }
-        .toMap()
+        .map(extractor)
+        .fold(LinkedHashMap<String, File>()) { acc, map -> acc.apply { putAll(map) } }
         .takeIf { it.isNotEmpty() }
-        .also { logger.debug { "Found ${it?.size} modules in project $projectPath." } }
+        ?.also { logger.debug { "Found ${it.size} modules in project $projectPath." } }
 
 fun detectBuildSystem(projectDirPath: File): BuildSystem {
     return when {

--- a/src/test/kotlin/BuildSystemTest.kt
+++ b/src/test/kotlin/BuildSystemTest.kt
@@ -1,4 +1,4 @@
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
@@ -12,6 +12,10 @@ class BuildSystemTest {
             include "project:projectj"
             include "project:core"
             include(":project:server")
+            include 'project:prj1', 'project:prj2'
+            include("project:prj3", 
+                "project:prj4"
+            )
         """.trimIndent()
         File(projectPath, "settings.gradle").writeText(settings)
         val resolvedModules = BuildSystem.GRADLE.getProjectModules(projectPath)
@@ -19,7 +23,45 @@ class BuildSystemTest {
             "project:projectj" to File(projectPath, "project/projectj"),
             "project:core" to File(projectPath, "project/core"),
             ":project:server" to File(projectPath, "project/server"),
+            "project:prj1" to File(projectPath, "project/prj1"),
+            "project:prj2" to File(projectPath, "project/prj2"),
+            "project:prj3" to File(projectPath, "project/prj3"),
+            "project:prj4" to File(projectPath, "project/prj4"),
             )
-        assertEquals(expectedModules, resolvedModules)
+        assertThat(resolvedModules).containsExactlyEntriesOf(expectedModules)
+    }
+
+    @Test
+    fun testDetectMavenModules(@TempDir projectPath: File) {
+        val pomXml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+              <modelVersion>4.0.0</modelVersion>
+            
+              <artifactId>test-parent</artifactId>
+              <packaging>pom</packaging>
+            
+              <name>Test Project</name>
+              <url>https://example.org</url>
+              <description>Test Java project</description>
+            
+              <properties>
+                <slf4j.version>1.7.36</slf4j.version>
+              </properties>
+            
+              <modules>
+                <module>android</module>
+                <module>maven-plugin</module>
+              </modules>
+            </project>
+        """.trimIndent()
+        File(projectPath, "pom.xml").writeText(pomXml)
+        val resolvedModules = BuildSystem.MAVEN.getProjectModules(projectPath)
+        val expectedModules = mapOf(
+            "android" to File(projectPath, "android"),
+            "maven-plugin" to File(projectPath, "maven-plugin"),
+        )
+        assertThat(resolvedModules).containsExactlyEntriesOf(expectedModules)
     }
 }


### PR DESCRIPTION
Resolves #44 

Now the following module declarations are supported:

```groovy
include 'module1', 'module2',
    'module3'
include("module4", 
  "module5")
```

Also, modules are searched recursively, so multi-level project like https://github.com/apache/avro should be parsed correctly
