### PR TITLE
Refactoring: Rename Runner to ProjectScanner, move resultWriter out of ProjectScanner

### DIFF
--- a/src/main/kotlin/CliRunner.kt
+++ b/src/main/kotlin/CliRunner.kt
@@ -5,8 +5,13 @@ import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.choice
 import com.github.ajalt.clikt.parameters.types.file
 import com.github.ajalt.clikt.parameters.types.int
+import mu.KotlinLogging
 import writers.OutputType
 import java.io.File
+import java.util.concurrent.Future
+import java.util.concurrent.LinkedBlockingQueue
+
+private val logger = KotlinLogging.logger {}
 
 class CliRunner: CliktCommand() {
     private val projects by option(help = "Path to file with projects").file(mustExist = true, canBeFile = true)
@@ -21,7 +26,19 @@ class CliRunner: CliktCommand() {
     private val cpuThreads by option(help = "Number of threads used for processing projects. Use 0 for common pool").int()
         .default(0)
 
-    override fun run() = Runner(projects, outputFormat, outputPath, repoStorage, ioThreads, cpuThreads).run()
+    override fun run() = ResultWriter.create(outputFormat, outputPath).use { resultWriter ->
+        logger.info { "Start processing projects in ${projects.path}..." }
+
+        val scanner = ProjectScanner(repoStorage, ioThreads, cpuThreads)
+        val tasks = LinkedBlockingQueue<Future<List<TestMethodInfo>>>()
+        val projectCount = projects.bufferedReader().useLines { it.count { path -> scanner.scanProject(path, tasks) } }
+
+        repeat(projectCount) {
+            tasks.take().valueOrNull()?.let { resultWriter.writeSynchronized(it) }
+        }
+
+        logger.info { "Finished processing projects." }
+    }
 }
 
 fun main(args: Array<String>) = CliRunner().main(args)

--- a/src/main/kotlin/ProjectScanner.kt
+++ b/src/main/kotlin/ProjectScanner.kt
@@ -23,8 +23,11 @@ class ProjectScanner private constructor(
         if (path.startsWith("http")) {
             taskExecutor.runDownloadingTask(GitRepoDownloadingTask(path, repoStorage))
                 .handle { repoPath, ex ->
-                    tasks += if (ex != null) CompletableFuture.failedFuture(ex)
-                    else taskExecutor.runComputationTask(ProjectProcessingTask(repoPath))
+                    tasks += if (ex != null) {
+                        CompletableFuture.failedFuture(ex)
+                    } else {
+                        taskExecutor.runComputationTask(ProjectProcessingTask(repoPath))
+                    }
                 }
         } else if (path.isNotBlank()) {
             tasks += taskExecutor.runComputationTask(ProjectProcessingTask(File(path)))

--- a/src/main/kotlin/Utils.kt
+++ b/src/main/kotlin/Utils.kt
@@ -1,3 +1,6 @@
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Future
+
 inline fun <T> namedThread(name: String, action: () -> T): T {
     val thread = Thread.currentThread()
     val oldName = thread.name
@@ -12,3 +15,10 @@ inline fun <T> namedThread(name: String, action: () -> T): T {
 class ParallelTask<R>(private val task: () -> R): java.util.concurrent.RecursiveTask<R>() {
     override fun compute(): R = task()
 }
+
+fun <T> Future<T>.valueOrNull(): T? =
+    try {
+        this.get()
+    } catch (e: ExecutionException) {
+        null
+    }

--- a/src/main/kotlin/writers/ResultWriter.kt
+++ b/src/main/kotlin/writers/ResultWriter.kt
@@ -1,4 +1,9 @@
+import writers.CsvResultWriter
+import writers.DBResultWriter
+import writers.JsonResultWriter
+import writers.OutputType
 import java.io.Closeable
+import java.io.File
 
 /**
  * Common interface for result writers.
@@ -8,4 +13,30 @@ import java.io.Closeable
 interface ResultWriter : Closeable {
     fun writeTestMethod(method: TestMethodInfo)
     fun writeTestMethods(methods: List<TestMethodInfo>) = methods.forEach { writeTestMethod(it) }
+
+    fun writeSynchronized(testMethodInfos: List<TestMethodInfo>) {
+        if (testMethodInfos.isNotEmpty()) {
+            synchronized(this) {
+                val projectName = testMethodInfos[0].classInfo.projectInfo.name
+                namedThread("${projectName}.resultWriter") {
+                    writeTestMethods(testMethodInfos)
+                }
+            }
+        }
+    }
+
+    companion object {
+        fun create(outputFormat: OutputType, outputPath: File): ResultWriter {
+            val outputFile = if (outputPath.isDirectory) {
+                File(outputPath, "results.${outputFormat.value}")
+            } else {
+                outputPath
+            }
+            return when (outputFormat) {
+                OutputType.JSON -> JsonResultWriter(outputFile.toPath())
+                OutputType.CSV -> CsvResultWriter(outputFile.toPath())
+                OutputType.SQLITE -> DBResultWriter("jdbc:sqlite:$outputFile")
+            }
+        }
+    }
 }


### PR DESCRIPTION
This change will help to reuse the logic with other interfaces, e.g. multi-user web application