### PR TITLE
CSV writer fixed

### DIFF
--- a/src/main/kotlin/Results.kt
+++ b/src/main/kotlin/Results.kt
@@ -23,9 +23,9 @@ data class TestClassInfo(
     @SerialName("package") val packageName: String,
     val projectInfo: ProjectInfo,
     val moduleInfo: ModuleInfo,
-    val sourceClass: SourceClassInfo?,
     val language: Lang,
-    val testFramework: TestFramework
+    val testFramework: TestFramework,
+    val sourceClass: SourceClassInfo?
 )
 
 @Serializable

--- a/src/main/kotlin/parsers/JvmTestsParser.kt
+++ b/src/main/kotlin/parsers/JvmTestsParser.kt
@@ -83,9 +83,9 @@ class JvmTestsParser(
             classMeta.packageName,
             module.projectInfo,
             module,
-            sourceClassAndLocation?.sourceClass,
             language,
-            testFramework
+            testFramework,
+            sourceClassAndLocation?.sourceClass
         )
         val isClassParameterized = isClassParameterized(classMeta, testFramework)
         val isClassDisabled = isClassDisabled(classMeta, testFramework)

--- a/src/test/kotlin/parsers/TestMethodExtractionTests.kt
+++ b/src/test/kotlin/parsers/TestMethodExtractionTests.kt
@@ -190,7 +190,7 @@ class TestMethodExtractionTests {
         val moduleInfo = createModule(pathToModule)
         val parser = createParser(lang, pathToModule, moduleInfo, emptyMap())
         val testFile = File(pathToModule, "src/test/${lang.name.lowercase()}/project/${className}.${lang.extension}")
-        val classInfo = TestClassInfo(className, "project", moduleInfo.projectInfo, moduleInfo, null, lang, framework)
+        val classInfo = TestClassInfo(className, "project", moduleInfo.projectInfo, moduleInfo, lang, framework, null)
 
         assertThat(parser.process(listOf(testFile))).usingRecursiveComparison()
             .isEqualTo(expectedResultProvider(classInfo))


### PR DESCRIPTION
Resolves #47 

Reorder fields so nullable fields go last. 
Add empty columns in CSV if source method or source class not found