### PR TITLE
Support writing result to multiple formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 
 It automatically downloads projects from GitHub, parses source code to identify unit tests, searches for the
 corresponding source methods, collects some metadata about the code, and stores the information in one of the following
-formats: ```JSON```, ```CSV```
-, ```SQLite```.
+formats: ```JSON```, ```CSV```, ```SQLite```.
 
 ## Getting started
 
@@ -29,11 +28,11 @@ To start processing the projects, run the command
 
 ```kute``` is a command-line application that could be run with the following options:
 
-| Name                  | Description                                                                         | 
-|-----------------------|-------------------------------------------------------------------------------------|
-| ```--projects```      | Path to the file with links to projects on GitHub.                                  |
-| ```--output-format``` | Format to store results in. Supported types: ```json```, ```csv```, ```sqlite```.   |
-| ```--output-path```   | Path to put file with results to.                                                   |
-| ```--repo-storage```   | Path to the directory to clone repositories to.                                     |
-| ```--io-threads```    | Number of threads used for downloading Git repos. Use 0 for common pool. Default: 1 |
-| ```--cpu-threads```   | Number of threads used for processing projects. Use 0 for common pool. Default: 0   |
+| Name                   | Description                                                                                                | 
+|------------------------|------------------------------------------------------------------------------------------------------------|
+| ```--projects```       | Path to the file with links to projects on GitHub.                                                         |
+| ```--output-formats``` | Comma-separated list of formats to store results in. Supported types: ```json```, ```csv```, ```sqlite```. |
+| ```--output-path```    | Path to put file with results to.                                                                          |
+| ```--repo-storage```   | Path to the directory to clone repositories to.                                                            |
+| ```--io-threads```     | Number of threads used for downloading Git repos. Use 0 for common pool. Default: 1                        |
+| ```--cpu-threads```    | Number of threads used for processing projects. Use 0 for common pool. Default: 0                          |

--- a/README.md
+++ b/README.md
@@ -36,3 +36,5 @@ To start processing the projects, run the command
 | ```--repo-storage```   | Path to the directory to clone repositories to.                                                            |
 | ```--io-threads```     | Number of threads used for downloading Git repos. Use 0 for common pool. Default: 1                        |
 | ```--cpu-threads```    | Number of threads used for processing projects. Use 0 for common pool. Default: 0                          |
+| ```--cleanup```        | Delete cloned Git repositories after processing. Default: disabled                                         |
+

--- a/src/main/kotlin/CliRunner.kt
+++ b/src/main/kotlin/CliRunner.kt
@@ -1,5 +1,6 @@
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.options.split
@@ -27,11 +28,12 @@ class CliRunner: CliktCommand() {
         .default(1)
     private val cpuThreads by option(help = "Number of threads used for processing projects. Use 0 for common pool").int()
         .default(0)
+    private val cleanup by option(help = "Delete cloned Git repos after processing").flag(default = false)
 
     override fun run() = ResultWriter.create(outputFormats, outputPath).use { resultWriter ->
         logger.info { "Start processing projects in ${projects.path}..." }
 
-        val scanner = ProjectScanner(repoStorage, ioThreads, cpuThreads)
+        val scanner = ProjectScanner(repoStorage, ioThreads, cpuThreads, cleanup)
         val tasks = LinkedBlockingQueue<Future<List<TestMethodInfo>>>()
         val projectCount = projects.bufferedReader().useLines { it.count { path -> scanner.scanProject(path, tasks) } }
 

--- a/src/main/kotlin/CliRunner.kt
+++ b/src/main/kotlin/CliRunner.kt
@@ -2,6 +2,8 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.options.split
+import com.github.ajalt.clikt.parameters.options.unique
 import com.github.ajalt.clikt.parameters.types.choice
 import com.github.ajalt.clikt.parameters.types.file
 import com.github.ajalt.clikt.parameters.types.int
@@ -16,8 +18,8 @@ private val logger = KotlinLogging.logger {}
 class CliRunner: CliktCommand() {
     private val projects by option(help = "Path to file with projects").file(mustExist = true, canBeFile = true)
         .required()
-    private val outputFormat by option(help = "Format to store results in. Supported formats: csv, json, sqlite")
-        .choice(OutputType.values().associateBy { it.value }).required()
+    private val outputFormats by option(help = "Comma-separated list of formats to store results in. Supported formats: csv, json, sqlite")
+        .choice(OutputType.values().associateBy { it.value }).split(",").required().unique()
     private val outputPath by option(help = "Path to output directory").file(canBeFile = true).required()
     private val repoStorage by option(help = "Path to the directory to clone repositories to").file(canBeFile = false)
         .default(File("repos"))
@@ -26,7 +28,7 @@ class CliRunner: CliktCommand() {
     private val cpuThreads by option(help = "Number of threads used for processing projects. Use 0 for common pool").int()
         .default(0)
 
-    override fun run() = ResultWriter.create(outputFormat, outputPath).use { resultWriter ->
+    override fun run() = ResultWriter.create(outputFormats, outputPath).use { resultWriter ->
         logger.info { "Start processing projects in ${projects.path}..." }
 
         val scanner = ProjectScanner(repoStorage, ioThreads, cpuThreads)

--- a/src/main/kotlin/writers/CompositeResultWriter.kt
+++ b/src/main/kotlin/writers/CompositeResultWriter.kt
@@ -1,0 +1,22 @@
+package writers
+
+import ResultWriter
+import TestMethodInfo
+
+class CompositeResultWriter(private val delegates: Array<ResultWriter>): ResultWriter {
+    override fun writeTestMethod(method: TestMethodInfo) {
+        delegates.forEach { it.writeTestMethod(method) }
+    }
+
+    override fun writeTestMethods(methods: List<TestMethodInfo>) {
+        delegates.forEach { it.writeTestMethods(methods) }
+    }
+
+    override fun writeSynchronized(testMethodInfos: List<TestMethodInfo>) {
+        delegates.forEach { it.writeSynchronized(testMethodInfos) }
+    }
+
+    override fun close() {
+        delegates.forEach { it.close() }
+    }
+}

--- a/src/main/kotlin/writers/ResultWriter.kt
+++ b/src/main/kotlin/writers/ResultWriter.kt
@@ -1,3 +1,4 @@
+import writers.CompositeResultWriter
 import writers.CsvResultWriter
 import writers.DBResultWriter
 import writers.JsonResultWriter
@@ -26,6 +27,15 @@ interface ResultWriter : Closeable {
     }
 
     companion object {
+        fun create(outputFormats: Set<OutputType>, outputPath: File): ResultWriter {
+            check(outputFormats.isNotEmpty()) { "outputFormats must be specified" }
+            if (outputFormats.size == 1) {
+                return create(outputFormats.first(), outputPath)
+            }
+            check(outputPath.isDirectory) { "outputPath must be a directory if multiple output formats specified" }
+            return CompositeResultWriter(outputFormats.map { create(it, outputPath) }.toTypedArray())
+        }
+
         fun create(outputFormat: OutputType, outputPath: File): ResultWriter {
             val outputFile = if (outputPath.isDirectory) {
                 File(outputPath, "results.${outputFormat.value}")


### PR DESCRIPTION
Replace `--output-format` with `--ouput-formats` accepting comma-separated list of formats, e.g. `csv,json,sqlite`
Support `--cleanup flag`