### PR TITLE
Optimize source method resolving

### DIFF
--- a/src/main/kotlin/mappers/MethodMeta.kt
+++ b/src/main/kotlin/mappers/MethodMeta.kt
@@ -5,9 +5,9 @@ interface MethodMeta {
     val parameters: List<Any>
     val comment: String
     val body: String
+    val isPublic: Boolean
 
-    fun hasMethodCall(sourceMethod: MethodMeta): Boolean
+    fun findLastMethodCall(sourceMethods: Map<String, List<MethodMeta>>): MethodMeta?
     fun hasAnnotation(name: String): Boolean
     fun getAnnotationValue(name: String, key: String? = null): String?
-    val isPublic: Boolean
 }

--- a/src/main/kotlin/mappers/SourceMethodMapper.kt
+++ b/src/main/kotlin/mappers/SourceMethodMapper.kt
@@ -7,9 +7,8 @@ object SourceMethodMapper {
     fun findSourceMethod(
         testMethod: MethodMeta,
         sourceClass: SourceClassInfo,
-        candidateMethods: List<MethodMeta>
-    ): SourceMethodInfo? {
-        return candidateMethods.find { testMethod.hasMethodCall(it) }
+        candidateMethods: Map<String, List<MethodMeta>>
+    ): SourceMethodInfo? =
+        testMethod.findLastMethodCall(candidateMethods)
             ?.let { SourceMethodInfo(it.name, it.body, sourceClass) }
-    }
 }

--- a/src/main/kotlin/parsers/JvmTestsParser.kt
+++ b/src/main/kotlin/parsers/JvmTestsParser.kt
@@ -89,7 +89,7 @@ class JvmTestsParser(
         )
         val isClassParameterized = isClassParameterized(classMeta, testFramework)
         val isClassDisabled = isClassDisabled(classMeta, testFramework)
-        var sourceMethodCandidates: List<MethodMeta>? = null
+        var sourceMethodCandidates: Map<String, List<MethodMeta>>? = null
 
         return classMeta.methods
             .mapNotNull { it ->
@@ -98,6 +98,7 @@ class JvmTestsParser(
                         if (sourceMethodCandidates == null) {
                             sourceMethodCandidates = getMetaFactoryByLanguage(detectLangByExtension(it.file.extension))
                                 .parseMethods(it.file)
+                                .groupBy { method -> method.name }
                         }
                         SourceMethodMapper.findSourceMethod(methodMeta, it.sourceClass, sourceMethodCandidates!!)
                     }


### PR DESCRIPTION
 - return last method instead of any used from source class
 - reduce complexity from O(N * M) to O(N + M)  where N is number of methods in a focal class and M is number of operations in the test method