### PR TITLE
Change ProjectScanner.scanProject method signature. 

### DIFF
--- a/src/main/kotlin/CliRunner.kt
+++ b/src/main/kotlin/CliRunner.kt
@@ -35,7 +35,9 @@ class CliRunner: CliktCommand() {
 
         val scanner = ProjectScanner(repoStorage, ioThreads, cpuThreads, cleanup)
         val tasks = LinkedBlockingQueue<Future<List<TestMethodInfo>>>()
-        val projectCount = projects.bufferedReader().useLines { it.count { path -> scanner.scanProject(path, tasks) } }
+        val projectCount = projects.bufferedReader().useLines { it.count {
+                path -> scanner.scanProject(path) { _, task -> tasks += task } != null }
+        }
 
         repeat(projectCount) {
             tasks.take().valueOrNull()?.let { resultWriter.writeSynchronized(it) }


### PR DESCRIPTION
Now it returns Future<Any>? instead of boolean so the tasks can be cancelled. 
Added processingTaskUpdater which allows to modify the task executed in cpu pool, e.g. add callback on finish

This PR would simplify HTTP API implementation